### PR TITLE
Deprecate md5 dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated all client-based value getting to behave sychronously
+- When getting a cookie value, added a check for md5 encryption and if found, we create new cookie without encryption and expire the old cookie
+
+### Deprecated
+
+- md5
 
 ## [0.5.1] - 2022-02-03
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ const featureFlagFromCookie = featureName => {
     Cookies.set(`feature_${featureName}`, cookieValue);
     Cookies.expire(md5(featureName));
   } else {
-    cookieValue = Cookies.get(featureName);
+    cookieValue = Cookies.get(`feature_${featureName}`);
   }
   return cookieValue;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,14 @@ const featuresCurrentFlags = features => {
 }
 
 const featureFlagFromCookie = featureName => {
-  return Cookies.get(md5(featureName));
+  let cookieValue = Cookies.get(md5(featureName));
+  if (cookieValue) {
+    Cookies.set(`feature_${featureName}`, cookieValue);
+    Cookies.expire(md5(featureName));
+  } else {
+    cookieValue = Cookies.get(featureName);
+  }
+  return cookieValue;
 }
 
 const cookieOptionsFromExpires = expires => {
@@ -75,7 +82,7 @@ export default function Signaler(urlOrFeatures, config = {}) {
   }
 
   const setFeatureFlag = (featureName, flag, options = {}) => {
-    Cookies.set(md5(featureName), flag, transformCookieOptions(options));
+    Cookies.set(`feature_${featureName}`, flag, transformCookieOptions(options));
   }
 
   return {

--- a/test/client_backed.test.js
+++ b/test/client_backed.test.js
@@ -83,21 +83,18 @@ describe('Signaler (client backed)', () => {
         Cookies.set(md5('featureWithMd5'), 'test');
       });
 
-      it('sets a new cookie w/o md5 encrpytion, expires the old cookie, and returns the flag value', async () => {
+      it('sets a new cookie w/o md5 encrpytion, expires the old cookie, and returns the flag value', () => {
         const features = {featureWithMd5: ['control', 'test'],}
         const signal = new Signaler(features);
         const featureName = 'featureWithMd5'
         const flag = signal.featureFlag(featureName)
-
-        await flag.then(data => {
-          expect(data).toEqual('test');
-          
-          const expiredCookieVal = Cookies.get(md5(featureName));
-          expect(expiredCookieVal).toEqual(undefined);
-          
-          const newCookieVal = Cookies.get(`feature_${featureName}`)
-          expect(newCookieVal).toMatch(/^test|control$/);
-        });
+        expect(flag).toEqual('test');
+        
+        const expiredCookieVal = Cookies.get(md5(featureName));
+        expect(expiredCookieVal).toEqual(undefined);
+        
+        const newCookieVal = Cookies.get(`feature_${featureName}`)
+        expect(newCookieVal).toMatch(/^test|control$/);
       })
     })
 

--- a/test/client_backed.test.js
+++ b/test/client_backed.test.js
@@ -28,15 +28,15 @@ const features = {
 
 describe('Signaler (client backed)', () => {
   beforeEach(() => {
-    Cookies.set('featureOne', 'control');
-    Cookies.set('featureTwo', 'test');
-    Cookies.set('featureThree', 'something');
+    Cookies.set('feature_featureOne', 'control');
+    Cookies.set('feature_featureTwo', 'test');
+    Cookies.set('feature_featureThree', 'something');
   });
 
   afterEach(() => {
-    Cookies.expire('featureOne');
-    Cookies.expire('featureTwo');
-    Cookies.expire('featureThree');
+    Cookies.expire('feature_featureOne');
+    Cookies.expire('feature_featureTwo');
+    Cookies.expire('feature_featureThree');
   });
 
   describe('setup', () => {

--- a/test/server_backed.test.js
+++ b/test/server_backed.test.js
@@ -1,5 +1,5 @@
 import {Promise} from 'es6-promise';
-import md5 from 'blueimp-md5';
+// import md5 from 'blueimp-md5';
 import Cookies from 'cookies-js';
 import Signaler from '../src';
 
@@ -7,15 +7,15 @@ window.fetch = jest.fn();
 
 describe('Signaler (server backed)', () => {
   beforeEach(() => {
-    Cookies.set(md5('featureOne'), 'control');
-    Cookies.set(md5('featureTwo'), 'test');
-    Cookies.set(md5('featureThree'), 'something');
+    Cookies.set('featureOne', 'control');
+    Cookies.set('featureTwo', 'test');
+    Cookies.set('featureThree', 'something');
   });
 
   afterEach(() => {
-    Cookies.expire(md5('featureOne'));
-    Cookies.expire(md5('featureTwo'));
-    Cookies.expire(md5('featureThree'));
+    Cookies.expire('featureOne');
+    Cookies.expire('featureTwo');
+    Cookies.expire('featureThree');
     window.fetch.mockClear();
   });
 
@@ -25,7 +25,7 @@ describe('Signaler (server backed)', () => {
 
   describe('setup', () => {
     it('sets url', () => {
-      var signal = new Signaler('myUrl');
+      const signal = new Signaler('myUrl');
       expect(signal.featureFlags).toBeInstanceOf(Function);
       expect(signal.featureFlagFromServer).toBeInstanceOf(Function);
       expect(signal.setFeatureFlag).toBeInstanceOf(Function);
@@ -94,7 +94,7 @@ describe('Signaler (server backed)', () => {
             expect(mockFetch).toHaveBeenCalledWith(`myUrl/${featureName}.json`);
             expect(data).toEqual(flagValue);
 
-            const cookieVal = Cookies.get(md5(featureName));
+            const cookieVal = Cookies.get(`feature_${featureName}`);
             expect(cookieVal).toEqual(flagValue);
           });
         });
@@ -117,7 +117,7 @@ describe('Signaler (server backed)', () => {
             expect(mockFetch).toHaveBeenCalledWith(`myUrl/${featureName}.json`);
             expect(data).toEqual(flagValue);
 
-            const cookieVal = Cookies.get(md5(featureName));
+            const cookieVal = Cookies.get(`feature_${featureName}`);
             expect(cookieVal).toEqual(flagValue);
           });
         });
@@ -138,7 +138,7 @@ describe('Signaler (server backed)', () => {
             expect(mockFetch).toHaveBeenCalledWith(`myUrl/${featureName}.json`);
             expect(data).toEqual(flagValue);
 
-            const cookieVal = Cookies.get(md5(featureName));
+            const cookieVal = Cookies.get(`feature_${featureName}`);
             expect(cookieVal).toEqual(flagValue);
           });
         });
@@ -153,15 +153,19 @@ describe('Signaler (server backed)', () => {
       jest.restoreAllMocks();
     });
 
+    beforeEach(() => {
+      cookieSpy.mockClear();
+    })
+
     it('sets the cookie with the options passed in', () => {
       const signal = new Signaler('myUrl');
       const featureName = 'newFeature';
       const featureVal = 'myVal';
 
       signal.setFeatureFlag(featureName, featureVal);
-      const cookieVal = Cookies.get(md5(featureName));
+      const cookieVal = Cookies.get(`feature_${featureName}`);
 
-      expect(cookieSpy).toHaveBeenCalledWith(md5(featureName), featureVal, {});
+      expect(cookieSpy).toHaveBeenCalledWith(`feature_${featureName}`, featureVal, {});
       expect(cookieVal).toEqual('myVal');
     });
 
@@ -175,8 +179,8 @@ describe('Signaler (server backed)', () => {
       const featureName = 'newFeature';
       const featureVal = 'myVal';
       signal.setFeatureFlag(featureName, featureVal, {domain: 'domain'});
-      const cookieVal = Cookies.get(md5(featureName));
-      expect(cookieSpy).toHaveBeenCalledWith(md5(featureName), featureVal, {
+      const cookieVal = Cookies.get(`feature_${featureName}`);
+      expect(cookieSpy).toHaveBeenCalledWith(`feature_${featureName}`, featureVal, {
         path: '/secret',
         domain: 'domain'
       });

--- a/test/server_backed.test.js
+++ b/test/server_backed.test.js
@@ -7,15 +7,15 @@ window.fetch = jest.fn();
 
 describe('Signaler (server backed)', () => {
   beforeEach(() => {
-    Cookies.set('featureOne', 'control');
-    Cookies.set('featureTwo', 'test');
-    Cookies.set('featureThree', 'something');
+    Cookies.set('feature_featureOne', 'control');
+    Cookies.set('feature_featureTwo', 'test');
+    Cookies.set('feature_featureThree', 'something');
   });
 
   afterEach(() => {
-    Cookies.expire('featureOne');
-    Cookies.expire('featureTwo');
-    Cookies.expire('featureThree');
+    Cookies.expire('feature_featureOne');
+    Cookies.expire('feature_featureTwo');
+    Cookies.expire('feature_featureThree');
     window.fetch.mockClear();
   });
 


### PR DESCRIPTION
### Description
We have used md5 to obfuscate our cookie feature names in this package however, the rest of the site's ecosystem doesn't obfuscate their cookies so in an attempt to make our package more inker friendly we are removing the obfuscation step of our cookie getting and setting.
<!--
Describe the relevant motivation and context for this change.
Please include a summary of the change as well as the issue that is fixed.
-->

### Changes
- removed mentions of md5 in `index.js`
- updated `featureFlagFromCookie` function to catch when an existing cookie has md5 encoding, create a new cookie without md5 encoding, expire the current cookie, and return the test value
- updated tests
<!--
Please describe your code changes in detail for reviewers. Explain the technical solution you have provided and how it addresses the issue at hand.
-->

##### Updated Dependencies
 - None
<!--
Please include any notes that might be helpful for a reviewer to check the dependency changes you might have introduced.
  - gem version update
  - new gem introduced
  - data model update
-->

### Optional Tasks

<!--
Common, optional tasks are included here in case you forgot something important.
-->

- [ ] Include 🎩 Instructions
- [ ] Update the readme (README.md)
- [ ] Update the API or architecture docs (e.g. docs/api.md)

##### Library-Specific

- [x] Increment the changelog (CHANGELOG.md)
- [ ] Increment the version number (lib/version.rb)
- [ ] [Release & Tag][release] the version above in Github

[release]: https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository

##### Performance
- Are there any new queries in your change set that might require new indexes?
- Do any new queries require time-boxing to avoid table-scans when the data grows?

### What GIF Best Describes This Pull Request?

![](https://media.giphy.com/media/Dnt2VnWFknFNm/giphy.gif)
